### PR TITLE
Add text style for markup.other scope.

### DIFF
--- a/Kuroir Theme.tmTheme
+++ b/Kuroir Theme.tmTheme
@@ -732,6 +732,21 @@
     </dict>
     <dict>
       <key>name</key>
+      <string>Markup: Other</string>
+      <key>scope</key>
+      <string>markup.other</string>
+      <key>settings</key>
+      <dict>
+        <key>background</key>
+        <string>#B1B3BA08</string>
+        <key>fontStyle</key>
+        <string></string>
+        <key>foreground</key>
+        <string>#578BB3</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
       <string>Log Entry</string>
       <key>scope</key>
       <string>meta.line.entry.logfile, meta.line.exit.logfile</string>


### PR DESCRIPTION
This is used, for example, in the DokuWiki syntax for line breaks (markup.other.paragraph.dokuwiki).
